### PR TITLE
bump actions/setup-go v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,10 +20,9 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v3
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go }}
-          cache: true
       - name: vet
         run: go vet ./...
       - name: Declare some variables


### PR DESCRIPTION
from v4, enabled caching by default.

see https://github.com/actions/setup-go#v4