### PR TITLE
migrate set-output to environment files.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Declare some variables
         id: vars
         run: |
-          echo "::set-output name=coverage_txt::${RUNNER_TEMP}/coverage.txt"
+          echo "coverage_txt=${RUNNER_TEMP}/coverage.txt" >> "$GITHUB_OUTPUT"
       - name: Test Coverage (pkg)
         run: go test ./... -race -coverprofile=${{ steps.vars.outputs.coverage_txt }}
       - name: Upload coverage


### PR DESCRIPTION
fix: Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

for example, https://github.com/Code-Hex/synchro/actions/runs/6065048196

<img width="1545" alt="image" src="https://github.com/Code-Hex/synchro/assets/1157344/dce5c028-28a4-4b55-9472-bd66645c5104">
