### PR TITLE
bump codecov/codecov-action v3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,6 @@ jobs:
         run: go test ./... -race -coverprofile=${{ steps.vars.outputs.coverage_txt }}
       - name: Upload coverage
         if: ${{ matrix.go == '^1.21' }}
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           files: ${{ steps.vars.outputs.coverage_txt }}


### PR DESCRIPTION
fix: The following actions uses node12 which is deprecated and will be forced to run on node16: codecov/codecov-action@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/