### PR TITLE
breaking change Change and Advance methods

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -2,220 +2,97 @@ package synchro
 
 import (
 	"time"
-
-	"github.com/Code-Hex/synchro/tz"
 )
 
-func toPtr[T any](x T) *T {
-	return &x
+type unit interface {
+	cast() int
 }
 
-// TimeBuilder defines an interface for constructing a Time[T] value
-// with specific date and time components using method chaining.
-//
-// Implementations should allow for setting each component step by step,
-// and then finalizing the construction with the Do() method.
-type TimeBuilder[T TimeZone] interface {
+type (
 	// Year sets the year component of the time being built.
-	Year(int) TimeBuilder[T]
+	Year int
 
 	// Month sets the month component of the time being built.
-	Month(time.Month) TimeBuilder[T]
+	Month int
 
 	// Day sets the day component of the time being built.
-	Day(int) TimeBuilder[T]
+	Day int
 
 	// Hour sets the hour component of the time being built.
-	Hour(int) TimeBuilder[T]
+	Hour int
 
 	// Minute sets the minute component of the time being built.
-	Minute(int) TimeBuilder[T]
+	Minute int
 
 	// Second sets the second component of the time being built.
-	Second(int) TimeBuilder[T]
+	Second int
 
 	// Nanosecond sets the nanosecond component of the time being built.
-	Nanosecond(int) TimeBuilder[T]
+	Nanosecond int
+)
 
-	// Do finalizes and returns the constructed Time value
-	// based on the components set in the chain.
-	Do() Time[T]
-}
+func (y Year) cast() int        { return int(y) }
+func (m Month) cast() int       { return int(m) }
+func (d Day) cast() int         { return int(d) }
+func (h Hour) cast() int        { return int(h) }
+func (m Minute) cast() int      { return int(m) }
+func (s Second) cast() int      { return int(s) }
+func (ns Nanosecond) cast() int { return int(ns) }
 
-type changeBuilder[T TimeZone] struct {
-	year   *int
-	month  *time.Month
-	day    *int
-	hour   *int
-	minute *int
-	second *int
-	nsec   *int
-
-	t Time[T]
-}
-
-var _ TimeBuilder[tz.UTC] = changeBuilder[tz.UTC]{}
-
-// Year implements the TimeBuilder interface to change years.
-func (c changeBuilder[T]) Year(year int) TimeBuilder[T] {
-	c.year = toPtr(year)
-	return c
-}
-
-// Month implements the TimeBuilder interface to change months.
-func (c changeBuilder[T]) Month(month time.Month) TimeBuilder[T] {
-	c.month = toPtr(month)
-	return c
-}
-
-// Day implements the TimeBuilder interface to change days.
-func (c changeBuilder[T]) Day(day int) TimeBuilder[T] {
-	c.day = toPtr(day)
-	return c
-}
-
-// Hour implements the TimeBuilder interface to change hours.
-func (c changeBuilder[T]) Hour(hour int) TimeBuilder[T] {
-	c.hour = toPtr(hour)
-	return c
-}
-
-// Minute implements the TimeBuilder interface to change minutes.
-func (c changeBuilder[T]) Minute(minute int) TimeBuilder[T] {
-	c.minute = toPtr(minute)
-	return c
-}
-
-// Second implements the TimeBuilder interface to change seconds.
-func (c changeBuilder[T]) Second(second int) TimeBuilder[T] {
-	c.second = toPtr(second)
-	return c
-}
-
-// Nanosecond implements the TimeBuilder interface to change nanoseconds.
-func (c changeBuilder[T]) Nanosecond(nsec int) TimeBuilder[T] {
-	c.nsec = toPtr(nsec)
-	return c
-}
-
-// Do implements the TimeBuilder interface to change any date and time components.
-func (c changeBuilder[T]) Do() Time[T] {
-	year, month, day := c.t.Date()
-	hour, min, sec := c.t.Clock()
-	nsec := c.t.Nanosecond()
-	if c.year != nil {
-		year = *c.year
-	}
-	if c.month != nil {
-		month = *c.month
-	}
-	if c.day != nil {
-		day = *c.day
-	}
-	if c.hour != nil {
-		hour = *c.hour
-	}
-	if c.minute != nil {
-		min = *c.minute
-	}
-	if c.second != nil {
-		sec = *c.second
-	}
-	if c.nsec != nil {
-		nsec = *c.nsec
+// Change modifies the time based on the provided unit values.
+// u1 is a required unit, while u2... can be provided as additional optional units.
+// This method returns a new Time[T] and does not modify the original.
+func (t Time[T]) Change(u1 unit, u2 ...unit) Time[T] {
+	year, month, day := t.Date()
+	hour, min, sec := t.Clock()
+	nsec := t.Nanosecond()
+	for _, u := range append([]unit{u1}, u2...) {
+		switch v := u.(type) {
+		case Year:
+			year = v.cast()
+		case Month:
+			month = time.Month(v.cast())
+		case Day:
+			day = v.cast()
+		case Hour:
+			hour = v.cast()
+		case Minute:
+			min = v.cast()
+		case Second:
+			sec = v.cast()
+		case Nanosecond:
+			nsec = v.cast()
+		}
 	}
 	return New[T](year, month, day, hour, min, sec, nsec)
 }
 
-// Change initializes and returns a TimeBuilder for the current Time value.
-//
-// This provides a method chain approach for specifying which parts of the time
-// you want to change, allowing for the creation of a new Time[T] instance
-// with the specified modifications.
-func (t Time[T]) Change() TimeBuilder[T] {
-	return changeBuilder[T]{t: t}
-}
-
-type advanceBuilder[T TimeZone] struct {
-	year   int
-	month  time.Month
-	day    int
-	hour   int
-	minute int
-	second int
-	nsec   int
-
-	t Time[T]
-}
-
-var _ TimeBuilder[tz.UTC] = advanceBuilder[tz.UTC]{}
-
-// Advance initializes and returns a TimeBuilder for the current Time value.
-//
-// This provides a method chain approach for specifying which parts of the time
-// you want to increment, allowing for the creation of a new Time[T] instance
-// with the specified modifications.
-func (t Time[T]) Advance() TimeBuilder[T] {
-	return advanceBuilder[T]{t: t}
-}
-
-// Year implements the TimeBuilder interface to increment years.
-func (a advanceBuilder[T]) Year(year int) TimeBuilder[T] {
-	a.year += year
-	return a
-}
-
-// Month implements the TimeBuilder interface to increment months.
-func (a advanceBuilder[T]) Month(month time.Month) TimeBuilder[T] {
-	a.month += month
-	return a
-}
-
-// Day implements the TimeBuilder interface to increment days.
-func (a advanceBuilder[T]) Day(day int) TimeBuilder[T] {
-	a.day += day
-	return a
-}
-
-// Hour implements the TimeBuilder interface to increment hours.
-func (a advanceBuilder[T]) Hour(hour int) TimeBuilder[T] {
-	a.hour += hour
-	return a
-}
-
-// Minute implements the TimeBuilder interface to increment minutes.
-func (a advanceBuilder[T]) Minute(minute int) TimeBuilder[T] {
-	a.minute += minute
-	return a
-}
-
-// Second implements the TimeBuilder interface to increment seconds.
-func (a advanceBuilder[T]) Second(second int) TimeBuilder[T] {
-	a.second += second
-	return a
-}
-
-// Nanosecond implements the TimeBuilder interface to increment nanoseconds.
-func (a advanceBuilder[T]) Nanosecond(nsec int) TimeBuilder[T] {
-	a.nsec += nsec
-	return a
-}
-
-// Do implements the TimeBuilder interface to increment any date and time components.
-func (a advanceBuilder[T]) Do() Time[T] {
-	t := a.t.AddDate(a.year, int(a.month), a.day)
-
-	if a.hour != 0 {
-		t = t.Add(time.Hour * time.Duration(a.hour))
+// Advance adjusts the time based on the provided unit values, moving it forward in time.
+// u1 is a required unit, while u2... can be provided as additional optional units.
+// This method returns a new Time[T] and does not modify the original.
+// The time is adjusted in the order the units are provided.
+func (t Time[T]) Advance(u1 unit, u2 ...unit) Time[T] {
+	ret := t
+	years, months, days := 0, time.Month(0), 0
+	for _, u := range append([]unit{u1}, u2...) {
+		switch v := u.(type) {
+		case Year:
+			years += v.cast()
+		case Month:
+			months += time.Month(v.cast())
+		case Day:
+			days += v.cast()
+		case Hour:
+			ret = ret.Add(time.Hour * time.Duration(v.cast()))
+		case Minute:
+			ret = ret.Add(time.Minute * time.Duration(v.cast()))
+		case Second:
+			ret = ret.Add(time.Second * time.Duration(v.cast()))
+		case Nanosecond:
+			ret = ret.Add(time.Duration(v.cast()))
+		}
 	}
-	if a.minute != 0 {
-		t = t.Add(time.Minute * time.Duration(a.minute))
-	}
-	if a.second != 0 {
-		t = t.Add(time.Second * time.Duration(a.second))
-	}
-	if a.nsec != 0 {
-		t = t.Add(time.Duration(a.nsec))
-	}
-	return t
+	year, month, day := ret.Date()
+	hour, min, sec := ret.Clock()
+	return New[T](year+years, month+months, day+days, hour, min, sec, ret.Nanosecond())
 }

--- a/builder_test.go
+++ b/builder_test.go
@@ -9,15 +9,24 @@ import (
 	"github.com/Code-Hex/synchro/tz"
 )
 
+// shorthand way
+type Y = synchro.Year
+type M = synchro.Month
+type D = synchro.Day
+type HH = synchro.Hour
+type MM = synchro.Minute
+type SS = synchro.Second
+type NS = synchro.Nanosecond
+
 func ExampleTime_Change() {
 	utc := synchro.New[tz.UTC](2009, time.November, 10, 23, 0, 0, 0)
-	c1 := utc.Change().Year(2010).Do()
-	c2 := utc.Change().Year(2010).Month(time.December).Do()
-	c3 := utc.Change().Year(2010).Month(time.December).Day(1).Do()
-	c4 := c3.Change().Hour(1).Do()
-	c5 := c3.Change().Hour(1).Minute(1).Do()
-	c6 := c3.Change().Hour(1).Minute(1).Second(1).Do()
-	c7 := c3.Change().Hour(1).Minute(1).Second(1).Nanosecond(123456789).Do()
+	c1 := utc.Change(synchro.Year(2010))
+	c2 := utc.Change(synchro.Year(2010), synchro.Month(time.December))
+	c3 := utc.Change(Y(2010), M(time.December), D(1))
+	c4 := c3.Change(synchro.Hour(1))
+	c5 := c3.Change(HH(1), MM(1))
+	c6 := c3.Change(HH(1), MM(1), SS(1))
+	c7 := c3.Change(HH(1), MM(1), SS(1), NS(123456789))
 	fmt.Printf("Go launched at %s\n", utc)
 	fmt.Println(c1)
 	fmt.Println(c2)
@@ -39,15 +48,15 @@ func ExampleTime_Change() {
 
 func ExampleTime_Advance() {
 	utc := synchro.New[tz.UTC](2009, time.November, 10, 23, 0, 0, 0)
-	c1 := utc.Advance().Year(1).Do()
-	c11 := utc.Advance().Year(1).Year(1).Do() // +2 years
+	c1 := utc.Advance(synchro.Year(1))
+	c11 := utc.Advance(Y(1), Y(1)) // +2 years
 
-	c2 := utc.Advance().Year(1).Month(1).Do()
-	c3 := utc.Advance().Year(1).Month(1).Day(1).Do()
-	c4 := c3.Advance().Hour(1).Do()
-	c5 := c3.Advance().Hour(1).Minute(1).Do()
-	c6 := c3.Advance().Hour(1).Minute(1).Second(1).Do()
-	c7 := c3.Advance().Hour(1).Minute(1).Second(1).Nanosecond(123456789).Do()
+	c2 := utc.Advance(Y(1), M(1))
+	c3 := utc.Advance(Y(1), M(1), D(1))
+	c4 := c3.Advance(HH(1))
+	c5 := c3.Advance(HH(1), MM(1))
+	c6 := c3.Advance(HH(1), MM(1), SS(1))
+	c7 := c3.Advance(HH(1), MM(1), SS(1), NS(123456789))
 
 	fmt.Printf("Go launched at %s\n", utc)
 	fmt.Println(c1)
@@ -76,42 +85,42 @@ func TestAdvance(t *testing.T) {
 	utc := synchro.New[tz.UTC](2009, time.November, 10, 23, 0, 0, 0)
 
 	t.Run("month twice", func(t *testing.T) {
-		got := utc.Advance().Month(1).Month(2).Do() // +3 months
+		got := utc.Advance(M(1), M(2)) // +3 months
 		want := synchro.New[tz.UTC](2010, time.February, 10, 23, 0, 0, 0)
 		if want != got {
 			t.Fatalf("- %s\n+ %s", want, got)
 		}
 	})
 	t.Run("day twice", func(t *testing.T) {
-		got := utc.Advance().Day(1).Day(2).Do() // +3 days
+		got := utc.Advance(D(1), D(2)) // +3 days
 		want := synchro.New[tz.UTC](2009, time.November, 13, 23, 0, 0, 0)
 		if want != got {
 			t.Fatalf("- %s\n+ %s", want, got)
 		}
 	})
 	t.Run("hour twice", func(t *testing.T) {
-		got := utc.Advance().Hour(1).Hour(2).Do() // +3 hours
+		got := utc.Advance(HH(1), HH(2)) // +3 hours
 		want := synchro.New[tz.UTC](2009, time.November, 11, 2, 0, 0, 0)
 		if want != got {
 			t.Fatalf("- %s\n+ %s", want, got)
 		}
 	})
 	t.Run("minute twice", func(t *testing.T) {
-		got := utc.Advance().Minute(5).Minute(60).Do() // +65 minutes
+		got := utc.Advance(MM(5), MM(60)) // +65 minutes
 		want := synchro.New[tz.UTC](2009, time.November, 11, 0, 5, 0, 0)
 		if want != got {
 			t.Fatalf("- %s\n+ %s", want, got)
 		}
 	})
 	t.Run("second twice", func(t *testing.T) {
-		got := utc.Advance().Second(5).Second(60).Do() // +65 seconds
+		got := utc.Advance(SS(5), SS(60)) // +65 seconds
 		want := synchro.New[tz.UTC](2009, time.November, 10, 23, 1, 5, 0)
 		if want != got {
 			t.Fatalf("- %s\n+ %s", want, got)
 		}
 	})
 	t.Run("nanosec twice", func(t *testing.T) {
-		got := utc.Advance().Nanosecond(5).Nanosecond(60).Do() // +65 nanosec
+		got := utc.Advance(NS(5), NS(60)) // +65 nanosec
 		want := synchro.New[tz.UTC](2009, time.November, 10, 23, 0, 0, 65)
 		if want != got {
 			t.Fatalf("- %s\n+ %s", want, got)


### PR DESCRIPTION
It has been discovered that when dealing with loops based on date and time conditions, method chaining is inefficient. Therefore, we will switch to an option-based format using types.

If you want to omit the package name, please use type aliases as shown in the example.

Example:
```go
// shorthand way
type Y = synchro.Year
type M = synchro.Month
type D = synchro.Day
type HH = synchro.Hour
type MM = synchro.Minute
type SS = synchro.Second
type NS = synchro.Nanosecond
```