### PR TITLE
Refactor time and date units to use exported type

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -4,7 +4,8 @@ import (
 	"time"
 )
 
-type unit interface {
+// Unit is a component of the time being built.
+type Unit interface {
 	cast() int
 }
 
@@ -42,11 +43,11 @@ func (ns Nanosecond) cast() int { return int(ns) }
 // Change modifies the time based on the provided unit values.
 // u1 is a required unit, while u2... can be provided as additional optional units.
 // This method returns a new Time[T] and does not modify the original.
-func (t Time[T]) Change(u1 unit, u2 ...unit) Time[T] {
+func (t Time[T]) Change(u1 Unit, u2 ...Unit) Time[T] {
 	year, month, day := t.Date()
 	hour, min, sec := t.Clock()
 	nsec := t.Nanosecond()
-	for _, u := range append([]unit{u1}, u2...) {
+	for _, u := range append([]Unit{u1}, u2...) {
 		switch v := u.(type) {
 		case Year:
 			year = v.cast()
@@ -71,10 +72,10 @@ func (t Time[T]) Change(u1 unit, u2 ...unit) Time[T] {
 // u1 is a required unit, while u2... can be provided as additional optional units.
 // This method returns a new Time[T] and does not modify the original.
 // The time is adjusted in the order the units are provided.
-func (t Time[T]) Advance(u1 unit, u2 ...unit) Time[T] {
+func (t Time[T]) Advance(u1 Unit, u2 ...Unit) Time[T] {
 	ret := t
 	years, months, days := 0, time.Month(0), 0
-	for _, u := range append([]unit{u1}, u2...) {
+	for _, u := range append([]Unit{u1}, u2...) {
 		switch v := u.(type) {
 		case Year:
 			years += v.cast()

--- a/civil.go
+++ b/civil.go
@@ -120,13 +120,13 @@ func (d *Date[T]) UnmarshalText(data []byte) error {
 // Change modifies the date based on the provided unit values.
 //
 // Note: Units related to time are ignored.
-func (t Date[T]) Change(u1 unit, u2 ...unit) Date[T] {
+func (t Date[T]) Change(u1 Unit, u2 ...Unit) Date[T] {
 	return DateOf[T](t.Time().Change(u1, u2...))
 }
 
 // Advance adjusts the date based on the provided unit values, moving it forward in date.
 //
 // Note: Units related to time are ignored.
-func (t Date[T]) Advance(u1 unit, u2 ...unit) Date[T] {
+func (t Date[T]) Advance(u1 Unit, u2 ...Unit) Date[T] {
 	return DateOf[T](t.Time().Advance(u1, u2...))
 }

--- a/civil_test.go
+++ b/civil_test.go
@@ -255,8 +255,8 @@ func TestUnmarshalJSON(t *testing.T) {
 func TestDateChange(t *testing.T) {
 	for _, test := range []struct {
 		date Date[tz.UTC]
-		u1   unit
-		u2   []unit
+		u1   Unit
+		u2   []Unit
 		want Date[tz.UTC]
 	}{
 		{
@@ -277,7 +277,7 @@ func TestDateChange(t *testing.T) {
 		{
 			date: Date[tz.UTC]{Year: 1987, Month: 4, Day: 15},
 			u1:   Year(1988),
-			u2:   []unit{Month(5), Day(10), Second(10)}, // ignore second
+			u2:   []Unit{Month(5), Day(10), Second(10)}, // ignore second
 			want: Date[tz.UTC]{Year: 1988, Month: 5, Day: 10},
 		},
 	} {
@@ -291,8 +291,8 @@ func TestDateChange(t *testing.T) {
 func TestDateAdvance(t *testing.T) {
 	for _, test := range []struct {
 		date Date[tz.UTC]
-		u1   unit
-		u2   []unit
+		u1   Unit
+		u2   []Unit
 		want Date[tz.UTC]
 	}{
 		{
@@ -313,7 +313,7 @@ func TestDateAdvance(t *testing.T) {
 		{
 			date: Date[tz.UTC]{Year: 1987, Month: 4, Day: 15},
 			u1:   Year(1),
-			u2:   []unit{Month(1), Day(-5), Second(10)}, // ignore second
+			u2:   []Unit{Month(1), Day(-5), Second(10)}, // ignore second
 			want: Date[tz.UTC]{Year: 1988, Month: 5, Day: 10},
 		},
 	} {

--- a/period.go
+++ b/period.go
@@ -137,7 +137,7 @@ func (p Period[T]) PeriodicDate(years int, months int, days int) periodical[T] {
 
 // PeriodicAdvance is a wrapper for the Periodic function.
 // The interval is specified by the provided date and time unit arguments.
-func (p Period[T]) PeriodicAdvance(u1 unit, u2 ...unit) periodical[T] {
+func (p Period[T]) PeriodicAdvance(u1 Unit, u2 ...Unit) periodical[T] {
 	return p.Periodic(func(t Time[T]) Time[T] {
 		return t.Advance(u1, u2...)
 	})


### PR DESCRIPTION
because want to use `unit` interface outside of this package. e.g. `var u synchro.Unit`