### PR TITLE
reduce memory allocation for struct fields

### DIFF
--- a/time.go
+++ b/time.go
@@ -10,8 +10,8 @@ import (
 type empty[T TimeZone] struct{}
 
 type Time[T TimeZone] struct {
-	tm time.Time
 	_  empty[T]
+	tm time.Time
 }
 
 // StdTime returns the time.Time.


### PR DESCRIPTION
There is no memory allocation by the zero-sized type (ZST) field itself, but the footprint of the struct may increase depending on the order in which struct fields are defined. In fact, the sample code below shows an increase of 8 bytes.

https://go.dev/play/p/fsAXJ17soKK

So reorder the fields to save the footprint.

ref. https://github.com/golang/go/issues/58483#issuecomment-1427182579