### PR TITLE
Reduce the footprint of Quarter and Semester

### DIFF
--- a/quarter.go
+++ b/quarter.go
@@ -5,7 +5,6 @@ import "time"
 type Quarter[T TimeZone] struct {
 	year   int
 	number int
-	t      Time[T]
 }
 
 // Quarter gets current quarter.
@@ -13,7 +12,6 @@ func (t Time[T]) Quarter() Quarter[T] {
 	return Quarter[T]{
 		year:   t.Year(),
 		number: numberOfQuarter(t.Month()),
-		t:      t,
 	}
 }
 
@@ -24,10 +22,21 @@ func (q Quarter[T]) Year() int { return q.year }
 func (q Quarter[T]) Number() int { return q.number }
 
 // Start returns start time in the quarter.
-func (q Quarter[T]) Start() Time[T] { return q.t.StartOfQuarter() }
+func (q Quarter[T]) Start() Time[T] {
+	year, quarter, day := q.year, q.number, 1
+	return New[T](year, time.Month(3*quarter-2), day, 0, 0, 0, 0)
+}
 
 // End returns end time in the quarter.
-func (q Quarter[T]) End() Time[T] { return q.t.EndOfQuarter() }
+func (q Quarter[T]) End() Time[T] {
+	year, quarter := q.year, q.number
+	day := 31
+	switch quarter {
+	case 2, 3:
+		day = 30
+	}
+	return New[T](year, time.Month(3*quarter), day, 23, 59, 59, 999999999)
+}
 
 // After reports whether the Quarter instant q is after u.
 func (q Quarter[T]) After(u Quarter[T]) bool {

--- a/semester.go
+++ b/semester.go
@@ -5,7 +5,6 @@ import "time"
 type Semester[T TimeZone] struct {
 	year   int
 	number int
-	t      Time[T]
 }
 
 // Semester gets current semester.
@@ -13,7 +12,6 @@ func (t Time[T]) Semester() Semester[T] {
 	return Semester[T]{
 		year:   t.Year(),
 		number: numberOfSemester(t.Month()),
-		t:      t,
 	}
 }
 
@@ -24,10 +22,24 @@ func (s Semester[T]) Year() int { return s.year }
 func (s Semester[T]) Number() int { return s.number }
 
 // Start returns start time in the semester.
-func (s Semester[T]) Start() Time[T] { return s.t.StartOfSemester() }
+func (s Semester[T]) Start() Time[T] {
+	year, semester, day := s.year, s.number, 1
+	month := time.January
+	if semester == 2 {
+		month = time.July
+	}
+	return New[T](year, month, day, 0, 0, 0, 0)
+}
 
 // End returns end time in the semester.
-func (s Semester[T]) End() Time[T] { return s.t.EndOfSemester() }
+func (s Semester[T]) End() Time[T] {
+	year, semester := s.year, s.number
+	month, day := time.June, 30
+	if semester == 2 {
+		month, day = time.December, 31
+	}
+	return New[T](year, month, day, 23, 59, 59, 999999999)
+}
 
 // After reports whether the Semester instant s is after u.
 func (s Semester[T]) After(u Semester[T]) bool {

--- a/time.go
+++ b/time.go
@@ -54,39 +54,22 @@ func (t Time[T]) EndOfWeek() Time[T] {
 
 // StartOfQuarter returns a Time for start of the quarter.
 func (t Time[T]) StartOfQuarter() Time[T] {
-	year, quarter, day := t.Year(), numberOfQuarter(t.Month()), 1
-	return New[T](year, time.Month(3*quarter-2), day, 0, 0, 0, 0)
+	return t.Quarter().Start()
 }
 
 // EndOfQuarter returns a Time for end of the quarter.
 func (t Time[T]) EndOfQuarter() Time[T] {
-	year, quarter := t.Year(), numberOfQuarter(t.Month())
-	day := 31
-	switch quarter {
-	case 2, 3:
-		day = 30
-	}
-	return New[T](year, time.Month(3*quarter), day, 23, 59, 59, 999999999)
+	return t.Quarter().End()
 }
 
 // StartOfSemester returns a Time for start of the semester.
 func (t Time[T]) StartOfSemester() Time[T] {
-	year, semester, day := t.Year(), numberOfSemester(t.Month()), 1
-	month := time.January
-	if semester == 2 {
-		month = time.July
-	}
-	return New[T](year, month, day, 0, 0, 0, 0)
+	return t.Semester().Start()
 }
 
 // EndOfSemester returns a Time for end of the semester.
 func (t Time[T]) EndOfSemester() Time[T] {
-	year, semester := t.Year(), numberOfSemester(t.Month())
-	month, day := time.June, 30
-	if semester == 2 {
-		month, day = time.December, 31
-	}
-	return New[T](year, month, day, 23, 59, 59, 999999999)
+	return t.Semester().End()
 }
 
 // IsLeapYear returns true if t is leap year.


### PR DESCRIPTION
The field `t Time[T]` in struct `Quarter` and `Semester` is irrelevant to the semantic of both structs, yet incurs unnecessary footprint overhead. Thus PR removes the field to reduce the size of aforementioned structs.