### PR TITLE
Drop dependency on reflect

### DIFF
--- a/period.go
+++ b/period.go
@@ -2,8 +2,8 @@ package synchro
 
 import (
 	"fmt"
-	"reflect"
 	"time"
+	"unsafe"
 
 	"github.com/Code-Hex/synchro/internal/constraints"
 	"github.com/Code-Hex/synchro/iso8601"
@@ -13,8 +13,6 @@ import (
 type timeish[T TimeZone] interface {
 	Time[T] | time.Time | constraints.Bytes
 }
-
-var stringType = reflect.TypeOf("")
 
 // Period allows iteration over a set of dates and times,
 // recurring at regular intervals, over a given period.
@@ -44,11 +42,11 @@ func (p Period[T]) To() Time[T] { return p.to }
 // When a string or []byte is passed, ParseISO function is called internally. Therefore, these
 // parameters should be in a format compatible with ParseISO.
 func NewPeriod[T TimeZone, T1 timeish[T], T2 timeish[T]](from T1, to T2) (Period[T], error) {
-	start, err := convertTime[T](any(from))
+	start, err := convertTime[T, T1](unsafe.Pointer(&from))
 	if err != nil {
 		return Period[T]{}, fmt.Errorf("failed to parse from: %w", err)
 	}
-	end, err := convertTime[T](any(to))
+	end, err := convertTime[T, T2](unsafe.Pointer(&to))
 	if err != nil {
 		return Period[T]{}, fmt.Errorf("failed to parse to: %w", err)
 	}
@@ -188,21 +186,17 @@ func (p Period[T]) PeriodicISODuration(duration string) (periodical[T], error) {
 	}), nil
 }
 
-func convertTime[T TimeZone](arg any) (Time[T], error) {
-	switch v := arg.(type) {
+func convertTime[T TimeZone, argType timeish[T]](argPtr unsafe.Pointer) (Time[T], error) {
+	var dummy argType
+	switch any(dummy).(type) {
 	case Time[T]:
-		return v, nil
+		return *(*Time[T])(argPtr), nil
 	case time.Time:
-		return In[T](v), nil
-	case string:
-		return ParseISO[T](v)
+		return In[T](*(*time.Time)(argPtr)), nil
 	case []byte:
-		return ParseISO[T](string(v))
+		return ParseISO[T](string(*(*[]byte)(argPtr)))
 	default:
-		rv := reflect.ValueOf(v)
-		if rv.CanConvert(stringType) {
-			return ParseISO[T](rv.Convert(stringType).String())
-		}
-		panic("unreachable")
+		// argType is ~string, argPtr can be safely converted to *string
+		return ParseISO[T](*(*string)(argPtr))
 	}
 }

--- a/period_test.go
+++ b/period_test.go
@@ -279,16 +279,6 @@ func TestPeriod_PeriodicISO(t *testing.T) {
 	})
 }
 
-// Unfortunate test to cover 100%
-func TestConvertTime_Panic(t *testing.T) {
-	defer func() {
-		if r := recover(); r == nil {
-			t.Errorf("The code did not panic")
-		}
-	}()
-	convertTime[tz.UTC](true)
-}
-
 func TestPeriod_Contains(t *testing.T) {
 	cases := []struct {
 		name string


### PR DESCRIPTION
Previously the code used `reflect` package to access a variable with bound `~string`. This can be improved by using unsafe.Pointer trick so that synchro can have no dependency on `reflect`.