### PR TITLE
Drop unnecessary dependencies by moving interface type asserts to tests

### DIFF
--- a/iso8601/date.go
+++ b/iso8601/date.go
@@ -1,7 +1,6 @@
 package iso8601
 
 import (
-	"encoding"
 	"fmt"
 	"math"
 	"strconv"
@@ -363,13 +362,6 @@ type Date struct {
 	Day   int
 }
 
-var _ interface {
-	DateLike
-	fmt.Stringer
-	encoding.TextMarshaler
-	encoding.TextUnmarshaler
-} = (*Date)(nil)
-
 // DateOf returns the iso8601 Date in which a time occurs in that time's location.
 func DateOf(t time.Time) Date {
 	var d Date
@@ -558,13 +550,6 @@ type QuarterDate struct {
 	Day     int
 }
 
-var _ interface {
-	DateLike
-	fmt.Stringer
-	encoding.TextMarshaler
-	encoding.TextUnmarshaler
-} = (*QuarterDate)(nil)
-
 // String returns the ISO8601 string representation of the format "YYYY-QX-DD".
 // For example: "2012-Q4-85".
 func (q QuarterDate) String() string {
@@ -657,13 +642,6 @@ type WeekDate struct {
 	Week int
 	Day  int
 }
-
-var _ interface {
-	DateLike
-	fmt.Stringer
-	encoding.TextMarshaler
-	encoding.TextUnmarshaler
-} = (*WeekDate)(nil)
 
 // String returns the ISO8601 string representation of the format "YYYY-WX-DD".
 // For example: "2012-W52-1".
@@ -760,13 +738,6 @@ type OrdinalDate struct {
 	Year int
 	Day  int
 }
-
-var _ interface {
-	DateLike
-	fmt.Stringer
-	encoding.TextMarshaler
-	encoding.TextUnmarshaler
-} = (*OrdinalDate)(nil)
 
 // String returns the ISO8601 string representation of the format "YYYY-DDD".
 // For example: "2012-359".

--- a/iso8601/date_test.go
+++ b/iso8601/date_test.go
@@ -1,12 +1,41 @@
 package iso8601
 
 import (
+	"encoding"
 	"fmt"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 )
+
+var _ interface {
+	DateLike
+	fmt.Stringer
+	encoding.TextMarshaler
+	encoding.TextUnmarshaler
+} = (*Date)(nil)
+
+var _ interface {
+	DateLike
+	fmt.Stringer
+	encoding.TextMarshaler
+	encoding.TextUnmarshaler
+} = (*QuarterDate)(nil)
+
+var _ interface {
+	DateLike
+	fmt.Stringer
+	encoding.TextMarshaler
+	encoding.TextUnmarshaler
+} = (*WeekDate)(nil)
+
+var _ interface {
+	DateLike
+	fmt.Stringer
+	encoding.TextMarshaler
+	encoding.TextUnmarshaler
+} = (*OrdinalDate)(nil)
 
 func Test_ParseDate(t *testing.T) {
 	tests := []struct {

--- a/iso8601/error.go
+++ b/iso8601/error.go
@@ -17,8 +17,6 @@ type UnexpectedTokenError struct {
 	Expected   string
 }
 
-var _ error = (*UnexpectedTokenError)(nil)
-
 // Error implements the error interface.
 func (u *UnexpectedTokenError) Error() string {
 	var buf strings.Builder

--- a/iso8601/error_test.go
+++ b/iso8601/error_test.go
@@ -2,6 +2,8 @@ package iso8601
 
 import "testing"
 
+var _ error = (*UnexpectedTokenError)(nil)
+
 func TestUnexpectedTokenError_Error(t *testing.T) {
 	tests := []struct {
 		err  *UnexpectedTokenError

--- a/iso8601/time.go
+++ b/iso8601/time.go
@@ -1,7 +1,6 @@
 package iso8601
 
 import (
-	"encoding"
 	"fmt"
 	"math"
 	"time"
@@ -18,12 +17,6 @@ type Time struct {
 	Second     int // The second of the minute; range [0-59]
 	Nanosecond int // The nanosecond of the second; range [0-999999999]
 }
-
-var _ interface {
-	fmt.Stringer
-	encoding.TextMarshaler
-	encoding.TextUnmarshaler
-} = (*Time)(nil)
 
 // TimeOf returns the Time representing the time of day in which a time occurs
 // in that time's location. It ignores the date.

--- a/iso8601/time_test.go
+++ b/iso8601/time_test.go
@@ -1,12 +1,20 @@
 package iso8601
 
 import (
+	"encoding"
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 )
+
+var _ interface {
+	fmt.Stringer
+	encoding.TextMarshaler
+	encoding.TextUnmarshaler
+} = (*Time)(nil)
 
 func TestParseTime(t *testing.T) {
 	tests := []struct {

--- a/period.go
+++ b/period.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/Code-Hex/synchro/internal/constraints"
 	"github.com/Code-Hex/synchro/iso8601"
-	"github.com/Code-Hex/synchro/tz"
 )
 
 type timeish[T TimeZone] interface {
@@ -22,10 +21,6 @@ type Period[T TimeZone] struct {
 	from Time[T]
 	to   Time[T]
 }
-
-var _ interface {
-	fmt.Stringer
-} = (*Period[tz.UTC])(nil)
 
 // String implements the fmt.Stringer interface.
 func (p Period[T]) String() string {

--- a/period_test.go
+++ b/period_test.go
@@ -1,6 +1,7 @@
 package synchro
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -9,6 +10,10 @@ import (
 	"github.com/Code-Hex/synchro/tz"
 	"github.com/google/go-cmp/cmp"
 )
+
+var _ interface {
+	fmt.Stringer
+} = (*Period[tz.UTC])(nil)
 
 func TestNewPeriod(t *testing.T) {
 	t.Run("want error for from", func(t *testing.T) {

--- a/sql.go
+++ b/sql.go
@@ -1,19 +1,12 @@
 package synchro
 
 import (
-	"database/sql"
 	"database/sql/driver"
 	"fmt"
 	"time"
 
 	"github.com/Code-Hex/synchro/iso8601"
-	"github.com/Code-Hex/synchro/tz"
 )
-
-var _ interface {
-	sql.Scanner
-	driver.Valuer
-} = (*Time[tz.UTC])(nil)
 
 // Scan implements the sql.Scanner interface.
 func (t *Time[T]) Scan(src any) error {
@@ -57,11 +50,6 @@ func (t *Time[T]) Scan(src any) error {
 func (t Time[T]) Value() (driver.Value, error) {
 	return t.tm, nil
 }
-
-var _ interface {
-	sql.Scanner
-	driver.Valuer
-} = (*NullTime[tz.UTC])(nil)
 
 // NullTime represents a Time[T] that may be null.
 // NullTime implements the sql.Scanner interface so

--- a/sql_test.go
+++ b/sql_test.go
@@ -1,6 +1,7 @@
 package synchro_test
 
 import (
+	"database/sql"
 	"database/sql/driver"
 	"testing"
 	"time"
@@ -8,6 +9,16 @@ import (
 	"github.com/Code-Hex/synchro"
 	"github.com/Code-Hex/synchro/tz"
 )
+
+var _ interface {
+	sql.Scanner
+	driver.Valuer
+} = (*synchro.Time[tz.UTC])(nil)
+
+var _ interface {
+	sql.Scanner
+	driver.Valuer
+} = (*synchro.NullTime[tz.UTC])(nil)
 
 func TestTime_Scan(t *testing.T) {
 	t.Run("UTC", func(t *testing.T) {

--- a/time_wrapper.go
+++ b/time_wrapper.go
@@ -1,27 +1,10 @@
 package synchro
 
 import (
-	"encoding"
-	"encoding/gob"
-	"encoding/json"
-	"fmt"
 	"time"
 
 	"github.com/Code-Hex/synchro/tz"
 )
-
-var _ interface {
-	fmt.Stringer
-	fmt.GoStringer
-	gob.GobEncoder
-	gob.GobDecoder
-	json.Marshaler
-	json.Unmarshaler
-	encoding.TextMarshaler
-	encoding.TextUnmarshaler
-	encoding.BinaryMarshaler
-	encoding.BinaryUnmarshaler
-} = (*Time[tz.UTC])(nil)
 
 // Local returns t with the location set to local time.
 func (t Time[T]) Local() Time[tz.Local] {

--- a/time_wrapper_test.go
+++ b/time_wrapper_test.go
@@ -2,6 +2,7 @@ package synchro_test
 
 import (
 	"bytes"
+	"encoding"
 	"encoding/gob"
 	"encoding/json"
 	"fmt"
@@ -13,6 +14,19 @@ import (
 	"github.com/Code-Hex/synchro"
 	"github.com/Code-Hex/synchro/tz"
 )
+
+var _ interface {
+	fmt.Stringer
+	fmt.GoStringer
+	gob.GobEncoder
+	gob.GobDecoder
+	json.Marshaler
+	json.Unmarshaler
+	encoding.TextMarshaler
+	encoding.TextUnmarshaler
+	encoding.BinaryMarshaler
+	encoding.BinaryUnmarshaler
+} = (*synchro.Time[tz.UTC])(nil)
 
 func TestMain(m *testing.M) {
 	os.Setenv("TZ", "America/Los_Angeles")


### PR DESCRIPTION
Currently the following program has a rather large binary size of ~2.0M (on Linux):

```go
package main

import (
	_ "github.com/Code-Hex/synchro"
)

func main() {
}
```

This is due to that code like below would introduce unnecessary dependencies to packages like `encoding/gob`:

```go
var _ interface {
	fmt.Stringer
	fmt.GoStringer
	gob.GobEncoder
	gob.GobDecoder
	json.Marshaler
	json.Unmarshaler
	encoding.TextMarshaler
	encoding.TextUnmarshaler
	encoding.BinaryMarshaler
	encoding.BinaryUnmarshaler
} = (*synchro.Time[tz.UTC])(nil)
```

By moving all interface type asserts to tests, the binary size of the above program would drop to ~1.5M, which is considerable.
