### PR TITLE
synchro: add fuzzer for ParseISO

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,3 +36,5 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           files: ${{ steps.vars.outputs.coverage_txt }}
+      - name: Fuzzing synchro pakcage
+        run: go test . -fuzz=Fuzz -fuzztime=300s

--- a/synchro_test.go
+++ b/synchro_test.go
@@ -204,3 +204,9 @@ func TestParseISO(t *testing.T) {
 
 	})
 }
+
+func FuzzParseISO(f *testing.F) {
+	f.Fuzz(func(t *testing.T, str string) {
+		_, _ = synchro.ParseISO[tz.UTC](str)
+	})
+}


### PR DESCRIPTION
Implement a fuzzer using the [Fuzzing feature of the Go standard](https://go.dev/doc/security/fuzz/) and run it continuously with CI.
This is particularly useful in finding vulnerabilities, as it allows them to reach edge cases that are often overlooked by humans.

## Details
- Implementation of FuzzParseISO
  - This explores whether there are any cases where ParseISO causes a panic.
  - A similar fuzzer has been implemented in [chrono](https://github.com/chronotope/chrono/blob/main/fuzz/fuzz_targets/fuzz_reader.rs), which served as an inspiration.
- Configuration for automatic execution in CI.
  - To provide rapid feedback to developers before merging into the base branch, Fuzzing will also be conducted in the Test workflow.
  - There are other approaches to test more comprehensively at a lower frequency (often referred to as Batch Fuzzing), but given the size of the codebase, this is considered unnecessary at present, as lightweight Fuzzing can achieve sufficient coverage.
  - Set to 300 second because the increase in 'New interesting' slows down and stops growing.

<details>
<summary>Graph showing the increase in "New interesting" when running for 10 minutes on GItHub Actions.</summary>

![image](https://github.com/Code-Hex/synchro/assets/49834542/00320cf8-0ee8-40fb-9e98-26c27a9a64a5)
</details> 



### References
- Go Fuzzing: https://go.dev/doc/security/fuzz/
- OSS-Fuzz docs: https://google.github.io/oss-fuzz/