### PR TITLE
ci: Change Fuzzing CI trigger to scheduled execution

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -1,0 +1,29 @@
+name: fuzzing
+on:
+  push:
+    branches:
+      - "main"
+    tags:
+      - "v*.*.*"
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  fuzzing:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        go:
+        - '^1.20'
+        - '^1.21'
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ matrix.go }}
+      - name: Fuzzing synchro package
+        run: go test . -fuzz=Fuzz -fuzztime=300s

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,5 +36,3 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           files: ${{ steps.vars.outputs.coverage_txt }}
-      - name: Fuzzing synchro package
-        run: go test . -fuzz=Fuzz -fuzztime=300s


### PR DESCRIPTION
Based on the following reasons, I propose transitioning to scheduled execution using cron settings:

- Since it's not possible to achieve complete coverage in a single test, we want to increase coverage by running tests periodically.
- Since it's uncertain whether contributors can detect issues at the time of commit, we want to exclude checks at the time of Pull Request and minimize stress on the contributing side.